### PR TITLE
adds interface builder support

### DIFF
--- a/SSDynamicText/SSDynamicLabel.m
+++ b/SSDynamicText/SSDynamicLabel.m
@@ -10,6 +10,9 @@
 
 @interface SSDynamicLabel ()
 
+@property (nonatomic, strong) NSString *fontName;
+@property (nonatomic, assign) CGFloat baseSize;
+
 - (void) setup;
 
 @end
@@ -17,7 +20,8 @@
 @implementation SSDynamicLabel
 
 - (id)init {
-    if( ( self = [super init] ) ) {
+    self = [super init];
+    if(self) {
         [self setup];
     }
   
@@ -25,19 +29,19 @@
 }
 
 - (id)initWithFrame:(CGRect)frame {
-    if( ( self = [super initWithFrame:frame] ) ) {
+    self = [super initWithFrame:frame];
+    if(self) {
         [self setup];
     }
-  
-  return self;
+    return self;
 }
 
-- (id)initWithCoder:(NSCoder *)aDecoder {
-    if( ( self = [super initWithCoder:aDecoder] ) ) {
+- (void)awakeFromNib
+{
+    if (self.fontName && self.baseSize) {
+        self.defaultFontDescriptor = [UIFontDescriptor fontDescriptorWithName:self.fontName size:self.baseSize];
         [self setup];
     }
-  
-    return self;
 }
 
 + (instancetype) labelWithFont:(NSString *)fontName baseSize:(CGFloat)size {

--- a/SSDynamicText/SSDynamicTextField.m
+++ b/SSDynamicText/SSDynamicTextField.m
@@ -10,6 +10,9 @@
 
 @interface SSDynamicTextField ()
 
+@property (nonatomic, strong) NSString *fontName;
+@property (nonatomic, assign) CGFloat baseSize;
+
 - (void) setup;
 
 @end
@@ -17,27 +20,27 @@
 @implementation SSDynamicTextField
 
 - (id)init {
-    if( ( self = [super init] ) ) {
+    self = [super init];
+    if(self) {
         [self setup];
     }
-    
     return self;
 }
 
 - (id)initWithFrame:(CGRect)frame {
-    if( ( self = [super initWithFrame:frame] ) ) {
+    self = [super initWithFrame:frame];
+    if(self) {
         [self setup];
     }
-    
     return self;
 }
 
-- (id)initWithCoder:(NSCoder *)aDecoder {
-    if( ( self = [super initWithCoder:aDecoder] ) ) {
+- (void)awakeFromNib
+{
+    if (self.fontName && self.baseSize) {
+        self.defaultFontDescriptor = [UIFontDescriptor fontDescriptorWithName:self.fontName size:self.baseSize];
         [self setup];
     }
-    
-    return self;
 }
 
 + (instancetype)textFieldWithFont:(NSString *)fontName baseSize:(CGFloat)size {

--- a/SSDynamicText/SSDynamicTextView.m
+++ b/SSDynamicText/SSDynamicTextView.m
@@ -10,6 +10,9 @@
 
 @interface SSDynamicTextView ()
 
+@property (nonatomic, strong) NSString *fontName;
+@property (nonatomic, assign) CGFloat baseSize;
+
 - (void) setup;
 
 @end
@@ -17,7 +20,8 @@
 @implementation SSDynamicTextView
 
 - (id)init {
-    if( ( self = [super init] ) ) {
+    self = [super init];
+    if(self) {
         [self setup];
     }
     
@@ -25,19 +29,19 @@
 }
 
 - (id)initWithFrame:(CGRect)frame {
-    if( ( self = [super initWithFrame:frame] ) ) {
+    self = [super initWithFrame:frame];
+    if(self) {
         [self setup];
     }
-    
     return self;
 }
 
-- (id)initWithCoder:(NSCoder *)aDecoder {
-    if( ( self = [super initWithCoder:aDecoder] ) ) {
+- (void)awakeFromNib
+{
+    if (self.fontName && self.baseSize) {
+        self.defaultFontDescriptor = [UIFontDescriptor fontDescriptorWithName:self.fontName size:self.baseSize];
         [self setup];
     }
-    
-    return self;
 }
 
 + (instancetype) textViewWithFont:(NSString *)fontName baseSize:(CGFloat)size {

--- a/SSDynamicText/UIView+SSTextSize.h
+++ b/SSDynamicText/UIView+SSTextSize.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2013 Splinesoft. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
+
 @interface UIView (SSTextSize)
 
 typedef void (^SSTextSizeChangedBlock) (NSInteger);


### PR DESCRIPTION
I added interface builder support for SSDynamicLabel, -TextField, and -TextView.

You have to use user defined runtime attributes with the keyPaths "fontName: String" and "baseSize: Number".
