### PR TITLE
Adds Default FontName and BaseSize for Interface Builder Support

### DIFF
--- a/SSDynamicText/SSDynamicLabel.m
+++ b/SSDynamicText/SSDynamicLabel.m
@@ -36,10 +36,12 @@
 }
 
 - (void)awakeFromNib {
-    if (self.fontName && self.baseSize) {
-        self.defaultFontDescriptor = [UIFontDescriptor fontDescriptorWithName:self.fontName size:self.baseSize];
-        [self setup];
-    }
+    self.fontName = (self.fontName) ? self.fontName : self.defaultFontName;
+    self.baseSize = (self.baseSize) ? self.baseSize : self.defaultBaseSize;
+    
+    self.defaultFontDescriptor = [UIFontDescriptor fontDescriptorWithName:self.fontName
+                                                                     size:self.baseSize];
+    [self setup];
 }
 
 + (instancetype) labelWithFont:(NSString *)fontName baseSize:(CGFloat)size {

--- a/SSDynamicText/SSDynamicTextField.m
+++ b/SSDynamicText/SSDynamicTextField.m
@@ -36,10 +36,12 @@
 }
 
 - (void)awakeFromNib {
-    if (self.fontName && self.baseSize) {
-        self.defaultFontDescriptor = [UIFontDescriptor fontDescriptorWithName:self.fontName size:self.baseSize];
-        [self setup];
-    }
+    self.fontName = (self.fontName) ? self.fontName : self.defaultFontName;
+    self.baseSize = (self.baseSize) ? self.baseSize : self.defaultBaseSize;
+    
+    self.defaultFontDescriptor = [UIFontDescriptor fontDescriptorWithName:self.fontName
+                                                                     size:self.baseSize];
+    [self setup];
 }
 
 + (instancetype)textFieldWithFont:(NSString *)fontName baseSize:(CGFloat)size {

--- a/SSDynamicText/SSDynamicTextView.m
+++ b/SSDynamicText/SSDynamicTextView.m
@@ -36,10 +36,12 @@
 }
 
 - (void)awakeFromNib {
-    if (self.fontName && self.baseSize) {
-        self.defaultFontDescriptor = [UIFontDescriptor fontDescriptorWithName:self.fontName size:self.baseSize];
-        [self setup];
-    }
+    self.fontName = (self.fontName) ? self.fontName : self.defaultFontName;
+    self.baseSize = (self.baseSize) ? self.baseSize : self.defaultBaseSize;
+    
+    self.defaultFontDescriptor = [UIFontDescriptor fontDescriptorWithName:self.fontName
+                                                                     size:self.baseSize];
+    [self setup];
 }
 
 + (instancetype) textViewWithFont:(NSString *)fontName baseSize:(CGFloat)size {

--- a/SSDynamicText/UIView+SSTextSize.h
+++ b/SSDynamicText/UIView+SSTextSize.h
@@ -36,4 +36,16 @@ typedef void (^SSTextSizeChangedBlock) (NSInteger);
  */
 - (void) preferredContentSizeDidChange;
 
+/**
+ * Default FontName if set in Info.plist or systemFontName
+ * Key: SSDynamicDefaultFontName
+ */
+- (NSString *)defaultFontName;
+
+/**
+ * DefaultBaseSize if set in Info.plist or 16.0
+ * Key: SSDynamicDefaultBaseSize
+ */
+- (CGFloat)defaultBaseSize;
+
 @end

--- a/SSDynamicText/UIView+SSTextSize.m
+++ b/SSDynamicText/UIView+SSTextSize.m
@@ -64,4 +64,17 @@ static char kDefaultFontDescriptorKey;
     [self setNeedsDisplay];
 }
 
+#pragma mark - DefaultFontName
+
+- (NSString *)defaultFontName {
+    NSString *defaultFontName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"SSDynamicDefaultFontName"];
+    return (defaultFontName) ? defaultFontName : [UIFont systemFontOfSize:self.defaultBaseSize].fontName;
+}
+
+- (CGFloat)defaultBaseSize {
+    float defaultBaseSize = [[[[NSBundle mainBundle] infoDictionary] objectForKey:@"SSDynamicDefaultBaseSize"] floatValue];
+    defaultBaseSize = (defaultBaseSize == 0.0) ? 16.0 : defaultBaseSize;
+    return defaultBaseSize;
+}
+
 @end


### PR DESCRIPTION
I added a default fontName and BaseSize for the interface builder support. I didn't add in on purpose for programmatically support because I could understand if you don't like to support it that way in code, but I find it very useful for the interface builder.
